### PR TITLE
Enable cors for api/walkin/profile route

### DIFF
--- a/app/server/routes/api.js
+++ b/app/server/routes/api.js
@@ -359,7 +359,8 @@ module.exports = function (router) {
   /**
    * Create a walkin user and updates user's profile.
    */
-  router.post('/walkin/profile', isValidSecret, (req, res) => {
+  router.options('/walkin/profile', cors());
+  router.post('/walkin/profile', cors(), isValidSecret, (req, res) => {
     console.log('Creating new walk-in user.');
 
     // create a new user and updates its fields


### PR DESCRIPTION
The walk-in form site is hosted on a separate domain, so cors must be enabled on the api/walkin/profile route for the ajax call to work...

<img width="1102" alt="screen shot 2018-10-28 at 3 14 41 pm" src="https://user-images.githubusercontent.com/12944187/47621671-44104a00-dac9-11e8-9b66-cb88445488c3.png">
<img width="1088" alt="screen shot 2018-10-28 at 3 14 50 pm" src="https://user-images.githubusercontent.com/12944187/47621672-47a3d100-dac9-11e8-922b-ebf27b523454.png">
